### PR TITLE
FIX auto_update_pricelist for default pricelist and order update

### DIFF
--- a/auto_update_pricelist/models/partner.py
+++ b/auto_update_pricelist/models/partner.py
@@ -120,6 +120,10 @@ class ResPartner(models.Model):
     def reset_partner_pricelist(self):
         for partner in self:
             default_pricelist = self.env['product.pricelist'].search([('is_default', '=', True)], limit=1)
+            price_list = partner.property_product_pricelist.product_pricelist_policy_id.pricelist_ids
+            for price_list_id in price_list:
+                if price_list_id.is_default:
+                    default_pricelist = procelist_id
             if default_pricelist:
                 partner.property_product_pricelist = default_pricelist
             partner._update_currenct_pricelist()

--- a/auto_update_pricelist/models/sale.py
+++ b/auto_update_pricelist/models/sale.py
@@ -19,7 +19,18 @@ class SaleOrder(models.Model):
         res = super(SaleOrder, self).action_cancel()
         for order in self:
             default_pricelist = self.env['product.pricelist'].search([('is_default', '=', True)], limit=1)
+            price_list = order.partner_id.property_product_pricelist.product_pricelist_policy_id.pricelist_ids
+            for procelist_id in price_list:
+                if procelist_id.is_default:
+                    default_pricelist = procelist_id
             if default_pricelist:
                 order.partner_id.property_product_pricelist = default_pricelist
+            order.partner_id._update_currenct_pricelist()
+        return res
+
+    @api.multi
+    def write(self, vals):
+        res = super(SaleOrder, self).write(vals)
+        for order in self:
             order.partner_id._update_currenct_pricelist()
         return res


### PR DESCRIPTION
FIX auto_update_pricelist for default pricelist and order update

- I just found out a behavior that a pricelist could be assign to a customer even the pricelist is not belong to the same Product Pricelist Policy. It is only occurred when default pricelist is re-assigned to the customer. - Done
- On the other hand, the pricelist seems do not update when editing a confirmed sale order. - Done